### PR TITLE
New check N410, added-argument-default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ from version 1.0.0 onwards.
 
 ## [Unreleased]
 
-- n/a
+### Added
+
+- New check `added-argument-default`: pidiff now reports when an existing argument
+  has a default value introduced
 
 ## [1.2.0] - 2019-05-25
 

--- a/docs/errors/signature.rst
+++ b/docs/errors/signature.rst
@@ -18,6 +18,7 @@ B340   removed-var-args
 B350   removed-var-keyword-args
 B800   uncallable
 N400   added-optional-argument
+N410   added-argument-default
 N440   added-var-args
 N450   added-var-keyword-args
 ====   =========================
@@ -137,6 +138,20 @@ Examples
 
         A named argument was added with a default value. Since a default is supplied,
         this is a backwards-compatible change.
+
+    .. index:: N410, added-argument-default
+
+    N410 added-argument-default
+        ::
+
+            -def scramble_eggs(with_butter)
+            +def scramble_eggs(with_butter=False)
+
+            # compatible: scramble_eggs(True)
+            # new call:   scramble_eggs()
+
+        An argument has a default value introduced. This is a backwards-compatible
+        change which allows a function to be called with fewer arguments.
 
     .. index:: N440, added-var-args
 

--- a/pidiff/_impl/diff/codes.py
+++ b/pidiff/_impl/diff/codes.py
@@ -162,6 +162,11 @@ class Codes:
         "added-optional-argument",
         "optional argument(s) added to {sym_new.display_name}: {extra[arg_name]}"
     )
+    AddedArgDefault = MinorCode(
+        "N410",
+        "added-argument-default",
+        "default value added to {sym_new.display_name} argument: {extra[arg_name]}"
+    )
     AddedVarArgs = MinorCode(
         "N440",
         "added-var-args",

--- a/pidiff/_impl/diff/diff.py
+++ b/pidiff/_impl/diff/diff.py
@@ -302,6 +302,11 @@ class Differ:
                               new_position=new_arg_idx)
                 raise StopDiff
 
+            new_arg = new_arg_names[idx]
+            if not sig_old.has_default_for(old_arg) and sig_new.has_default_for(new_arg):
+                self.AddedArgDefault(sym_old, sym_new,
+                                     arg_name=old_arg)
+
     def diff_named_args(self, sym_old, sym_new):
         sig_old = sym_old.ob.signature
         sig_new = sym_new.ob.signature

--- a/tests/data/diff_signatures_with_options_logs.txt
+++ b/tests/data/diff_signatures_with_options_logs.txt
@@ -8,6 +8,7 @@ test_api/signatures2.py:38: B340 mult_any no longer accepts unlimited positional
 test_api/signatures2.py:13: N440 mult_minor1 now accepts unlimited positional arguments
 test_api/signatures2.py:18: N440 mult_minor2 now accepts unlimited positional arguments
 test_api/signatures2.py:18: N450 mult_minor2 now accepts unlimited keyword arguments
+test_api/signatures2.py:48: N410 default value added to return_something argument: added_default
 
 ---------------------------------------------------------------------
 Major API changes were found; inappropriate for unknown versions

--- a/tests/data/test_signatures_logs.txt
+++ b/tests/data/test_signatures_logs.txt
@@ -10,4 +10,5 @@ test_api/signatures2.py:38: B340 tests.test_api.signatures2.mult_any no longer a
 test_api/signatures2.py:13: N440 tests.test_api.signatures2.mult_minor1 now accepts unlimited positional arguments
 test_api/signatures2.py:18: N440 tests.test_api.signatures2.mult_minor2 now accepts unlimited positional arguments
 test_api/signatures2.py:18: N450 tests.test_api.signatures2.mult_minor2 now accepts unlimited keyword arguments
+test_api/signatures2.py:48: N410 default value added to tests.test_api.signatures2.return_something argument: added_default
 Major API changes were found; inappropriate for unknown versions

--- a/tests/data/test_signatures_with_options_logs.txt
+++ b/tests/data/test_signatures_with_options_logs.txt
@@ -8,4 +8,5 @@ test_api/signatures2.py:38: B340 tests.test_api.signatures2.mult_any no longer a
 test_api/signatures2.py:13: N440 tests.test_api.signatures2.mult_minor1 now accepts unlimited positional arguments
 test_api/signatures2.py:18: N440 tests.test_api.signatures2.mult_minor2 now accepts unlimited positional arguments
 test_api/signatures2.py:18: N450 tests.test_api.signatures2.mult_minor2 now accepts unlimited keyword arguments
+test_api/signatures2.py:48: N410 default value added to tests.test_api.signatures2.return_something argument: added_default
 Major API changes were found; inappropriate for unknown versions

--- a/tests/test_api/signatures1.py
+++ b/tests/test_api/signatures1.py
@@ -35,3 +35,7 @@ def mult_any(*args):
 
 def do_anything(**kwargs):
     pass
+
+
+def return_something(x, added_default):
+    pass

--- a/tests/test_api/signatures2.py
+++ b/tests/test_api/signatures2.py
@@ -43,3 +43,7 @@ def mult_any(x, y, z, **kwargs):
 def do_anything(x, y, z, *args):
     # Major break: **kwargs was dropped
     pass
+
+
+def return_something(x, added_default=None):
+    pass


### PR DESCRIPTION
Detect when a default value is added to an argument.
This is a backwards-compatible API change.