### PR TITLE
Change default workdir to use XDG_CACHE_HOME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ from version 1.0.0 onwards.
 
 ## [Unreleased]
 
-- n/a
+### Changed
+
+- The `pidiff` command now stores virtual environments under the
+  `XDG_CACHE_HOME` directory by default, rather than a `.pidiff` directory.
 
 ## [1.3.0] - 2019-06-05
 

--- a/tests/command/test_cache.py
+++ b/tests/command/test_cache.py
@@ -1,0 +1,100 @@
+import os
+from unittest import mock
+
+from pidiff._impl import command
+
+
+def test_ensure_exists(tmpdir):
+    path = str(tmpdir.join('test-path'))
+    command.ensure_exists(path)
+    command.ensure_exists(path)
+
+    assert os.path.exists(path)
+
+
+def test_cache(tmpdir, monkeypatch):
+    cache = tmpdir.mkdir('cache')
+    monkeypatch.setenv('XDG_CACHE_HOME', str(cache))
+
+    cache_pidiff = cache.mkdir('pidiff')
+
+    # Make some new dirs
+    cache_pidiff.mkdir('newdir1')
+    cache_pidiff.mkdir('newdir2')
+
+    # Then some old dirs which should be removed
+    cache_pidiff.mkdir('olddir1').setmtime(1000)
+    cache_pidiff.mkdir('olddir2').setmtime(10000)
+
+    # Now let's try getting path to a virtualenv
+    args = mock.Mock()
+    args.workdir = None
+
+    path = command.make_venv_path('some-dist', args)
+
+    # It should assemble same path again for same dist
+    assert path == command.make_venv_path('some-dist', args)
+    basename = os.path.basename(path)
+
+    # Let's see what exists after that creation
+    cache_dirs = [x.basename for x in cache_pidiff.listdir()]
+    assert 'newdir1' in cache_dirs
+    assert 'newdir2' in cache_dirs
+    assert basename in cache_dirs
+
+    # Nothing else present (old dirs should be cleaned)
+    assert len(cache_dirs) == 3
+
+
+def test_cache_uses_reqs(tmpdir, monkeypatch):
+    cache = tmpdir.mkdir('cache')
+    monkeypatch.setenv('XDG_CACHE_HOME', str(cache))
+
+    dist = tmpdir.mkdir('dist')
+    setup_py = dist.join('setup.py')
+    setup_py.write('some content')
+
+    args = mock.Mock()
+    args.workdir = None
+
+    path1 = command.make_venv_path(str(dist), args)
+
+    # If setup.py content changes, cache path should also change
+    setup_py.write('more content')
+
+    path2 = command.make_venv_path(str(dist), args)
+
+    assert os.path.exists(path1)
+    assert os.path.exists(path2)
+    assert path1 != path2
+
+
+def test_cache_recreates(tmpdir, monkeypatch):
+    cache = tmpdir.mkdir('cache')
+    monkeypatch.setenv('XDG_CACHE_HOME', str(cache))
+
+    args = mock.Mock()
+    args.workdir = None
+
+    path1 = command.make_venv_path('some-dist', args)
+
+    # Make a subdir so we can verify it disappears later
+    sub_path = os.path.join(path1, 'subdir')
+    os.makedirs(sub_path)
+
+    # Ask to make the same venv again, but this time with recreate
+    args.recreate = True
+    path2 = command.make_venv_path('some-dist', args)
+
+    # It should make the same dir
+    assert path1 == path2
+
+    # It should have recreated the dir
+    assert not os.path.exists(sub_path)
+
+
+def test_clean_cache_swallows_errors():
+    with mock.patch('glob.glob') as mock_glob:
+        mock_glob.side_effect = OSError()
+        # It should complete without raising
+        command.cachedir()

--- a/tests/data/typical_diff_minorbad_logs.txt
+++ b/tests/data/typical_diff_minorbad_logs.txt
@@ -1,6 +1,7 @@
-Creating virtualenvs under <tmpdir>
-Installing foopkg==1.0.0 to <tmpdir>/s1
-Installing foopkg==1.1.0 to <tmpdir>/s2
+Creating virtualenv at <tmpdir>/cache1
+Creating virtualenv at <tmpdir>/cache2
+Installing foopkg==1.0.0 to <tmpdir>/cache1
+Installing foopkg==1.1.0 to <tmpdir>/cache2
 Inspecting API for foopkg==1.0.0
 Inspecting API for foopkg==1.1.0
 test_api/minorbad2.py:5: N220 function added: new_fn


### PR DESCRIPTION
Using .pidiff under the current working directory (when run from
a git repo) hasn't worked out too well. The main issue is that
no existing tools will skip processing of that directory by default,
so e.g. pylint, pytest, mypy and IDEs would descend into the
virtualenvs installed there, which is not desired.

Revise the default to make use of a cache under
$XDG_CACHE_HOME/pidiff:

- a subdir is created per virtualenv
- subdir name is derived from the package about to be installed
- cache is cleaned up on each run to avoid growing too large

Fixes #24 