### PR TITLE
Support common & arbitrary pip arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ from version 1.0.0 onwards.
 
 - ``--gen-version`` option was introduced for programmatic use. This option can be
   used to implement automated version bumps for a project.
+- ``--pip-args`` and related options were introduced to support passing
+  additional arguments to pip.
 
 ### Fixed
 

--- a/pidiff/_impl/pipargs.py
+++ b/pidiff/_impl/pipargs.py
@@ -1,0 +1,36 @@
+import shlex
+
+
+class PipArgs:
+    def __init__(self, pidiff_args):
+        self.pidiff_args = pidiff_args
+
+    @property
+    def excluding_requirements(self):
+        out = []
+
+        if self.pidiff_args.index_url:
+            out.extend(["-i", self.pidiff_args.index_url])
+
+        for url in self.pidiff_args.extra_index_url or []:
+            out.extend(["--extra-index-url", url])
+
+        if self.pidiff_args.pip_args:
+            out.extend(shlex.split(self.pidiff_args.pip_args))
+
+        return out
+
+    @property
+    def all(self):
+        out = self.excluding_requirements
+
+        for x in self.pidiff_args.requirement or []:
+            out.extend(["-r", x])
+
+        for x in self.pidiff_args.constraint or []:
+            out.extend(["-c", x])
+
+        if self.pidiff_args.pre:
+            out.append("--pre")
+
+        return out

--- a/tests/command/test_pipargs.py
+++ b/tests/command/test_pipargs.py
@@ -1,0 +1,64 @@
+from pidiff._impl.command import argparser, PipArgs
+
+PARSER = argparser()
+
+
+def test_all_pip_args():
+    parsed = PARSER.parse_args(
+        [
+            "--requirement",
+            "abc",
+            "--requirement",
+            "def",
+            "--constraint",
+            "aaa",
+            "-c",
+            "bbb",
+            "--pre",
+            "--index-url",
+            "idx1",
+            "--extra-index-url",
+            "idx2",
+            "--extra-index-url",
+            "idx3",
+            "--pip-args",
+            "arg1 'arg 2' other-arg",
+            "src1",
+            "src2",
+        ]
+    )
+
+    pipargs = PipArgs(parsed)
+
+    assert pipargs.excluding_requirements == [
+        "-i",
+        "idx1",
+        "--extra-index-url",
+        "idx2",
+        "--extra-index-url",
+        "idx3",
+        "arg1",
+        "arg 2",
+        "other-arg",
+    ]
+    assert pipargs.all == pipargs.excluding_requirements + [
+        "-r",
+        "abc",
+        "-r",
+        "def",
+        "-c",
+        "aaa",
+        "-c",
+        "bbb",
+        "--pre",
+    ]
+
+
+def test_empty_pip_args():
+    parsed = PARSER.parse_args(["src1", "src2",])
+
+    pipargs = PipArgs(parsed)
+
+    assert pipargs.excluding_requirements == []
+    assert pipargs.all == []
+


### PR DESCRIPTION
It is useful to control pip's behavior during install of the
tested packages, e.g. to install additional dependencies.