### PR TITLE
Make --requirements, --constraints work as expected for relative path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ from version 1.0.0 onwards.
 
 ## [Unreleased]
 
-- n/a
+### Fixed
+
+- Fixed handling of `--requirement`, `--constraint` when relative paths are
+  provided
 
 ## [1.5.0] - 2020-06-27
 

--- a/pidiff/_impl/pipargs.py
+++ b/pidiff/_impl/pipargs.py
@@ -1,9 +1,21 @@
 import shlex
+import os
 
 
 class PipArgs:
-    def __init__(self, pidiff_args):
+    def __init__(self, pidiff_args, workdir=None):
         self.pidiff_args = pidiff_args
+        self.workdir = workdir or os.getcwd()
+
+    def _absolutize(self, path):
+        # if path is relative and points at an existing file,
+        # then return absolute form of the path.
+        if not os.path.isabs(path):
+            candidate = os.path.join(self.workdir, path)
+            candidate = os.path.abspath(candidate)
+            if os.path.exists(candidate):
+                return candidate
+        return path
 
     @property
     def excluding_requirements(self):
@@ -25,10 +37,10 @@ class PipArgs:
         out = self.excluding_requirements
 
         for x in self.pidiff_args.requirement or []:
-            out.extend(["-r", x])
+            out.extend(["-r", self._absolutize(x)])
 
         for x in self.pidiff_args.constraint or []:
-            out.extend(["-c", x])
+            out.extend(["-c", self._absolutize(x)])
 
         if self.pidiff_args.pre:
             out.append("--pre")

--- a/tests/command/test_pipargs.py
+++ b/tests/command/test_pipargs.py
@@ -62,3 +62,34 @@ def test_empty_pip_args():
     assert pipargs.excluding_requirements == []
     assert pipargs.all == []
 
+
+def test_files_absolutized(tmpdir):
+    tmpdir.join("req1.txt").write("abc")
+    tmpdir.join("con1.txt").write("abc")
+
+    parsed = PARSER.parse_args(
+        [
+            "--requirement",
+            "req1.txt",
+            "--requirement",
+            "req2.txt",
+            "--constraint",
+            "con1.txt",
+            "src1",
+            "src2",
+        ]
+    )
+
+    pipargs = PipArgs(parsed, workdir=str(tmpdir))
+
+    assert pipargs.all == [
+        "-r",
+        # It should have figured out full path to existing req1.txt
+        str(tmpdir.join("req1.txt")),
+        "-r",
+        # It should have left this one alone since req2.txt doesn't exist
+        "req2.txt",
+        "-c",
+        # Same should work for constraints
+        str(tmpdir.join("con1.txt")),
+    ]


### PR DESCRIPTION
When virtualenvapi runs pip, it does not use the current working
directory, so any relative paths will not resolve (or could resolve
to something unexpected). Absolutize paths before invoking pip.