### PR TITLE
Drop codecov in favor of --cov-fail-under

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,13 +46,6 @@ workflows:
         - run: scripts/push-docs
         filters:
           <<: *post_merge_filters
-    - python/codeclimate-upload-coverage:
-        name: Submit coverage results to codeclimate
-        test_reporter_id: b5167e87a147f386af54fb218c710b65bafa6391ceeb2f37f82525f16eb32fc2
-        requires:
-        - Python 3.8 tests
-        filters:
-          <<: *ci_filters
     - python/release:
         name: Release to PyPI
         # For twine credentials

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ passenv = CIRCLE* CI*
 deps=-rtest-requirements.txt
 commands=
   pytest --cov-report=html --cov=pidiff -v \
+    --cov-fail-under=100 \
     --junit-xml=test-results/pidiff/junit.xml {posargs}
 whitelist_externals=sh
 


### PR DESCRIPTION
circle => codecov integration has broken, and since the coverage
is fixed at 100% anyway I don't feel like looking into it.