### PR TITLE
Use importlib.metadata for improved version lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ from version 1.0.0 onwards.
 
 ## [Unreleased]
 
-- n/a
+### Fixed
+
+- Version detection of the tested modules is now more accurate in some cases,
+  via usage of `importlib.metadata`.
+
+### Changed
+
+- Now requires python 3.8 or later.
 
 ## [1.6.0] - 2020-07-01
 

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
     long_description=get_long_description(),
     long_description_content_type="text/markdown",
     install_requires=get_install_requires(),
+    python_requires='>=3.8',
     entry_points={"console_scripts": ["pidiff=pidiff._impl.command:main"]},
     project_urls={
         "Documentation": "https://pidiff.dev/",


### PR DESCRIPTION
This is hopefully better than the other methods of detecting the
version.